### PR TITLE
Add command to list all plugin parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,99 @@
 # Plugalyzer
-Plugalyzer is a command-line VST3, AU and LADSPA host meant to ease debugging of audio plugins by making it possible to run them in non-realtime outside of a conventional DAW.
+A command-line VST3, AU and LADSPA host meant to ease debugging of audio plugins by making it possible to run them in non-realtime outside of a conventional DAW.
 
 It processes audio from input files using the desired plugin, writing the result to an output file.  
 Plugins with multiple input buses (such as sidechains) are supported.
 
-## Usage
-| Option                   | Description                                                                                                            | Required |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------|----------|
-| `--plugin=<path>`        | Path to, or identifier of the plugin to use.                                                                           | Yes      |
-| `--input=<path>`         | Path to an input file.<br>To supply multiple input files, provide the `--input` argument multiple times.               | Yes      |
-| `--output=<path>`        | Path to write the processed audio to.                                                                                  | Yes      |
-| `--override`             | Overridde the output file if it exists.<br>If this option is not set, processing is aborted if the output file exists. | No       |
-| `--blockSize=<number>`   | The amount of samples to send to the audio plugin at once for processing. Defaults to 1024.                            | No       |
-| `--outChannels=<number>` | The amount of channels to use for the plugin's output bus. Defaults to the amount of channels of the first input file. | No       | 
+# Table of Contents
+- [Usage](#usage)
+  - [Process audio files](#process-audio-files)
+    - [Bus layouts](#bus-layouts) 
+    - [Processing limitations](#processing-limitations)
+  - [List plugin parameters](#list-plugin-parameters)
+    - [Limitations](#limitations)
+- [Installation](#installation)
+
+# Usage
+The general usage of plugalyzer follows the pattern `plugalyzer [command] [options...]`.  
+Available commands and their options are described below.
+
+## Process audio files
+The `process` command processes one or more audio files using the given plugin in non-realtime,
+writing the processed audio to an output file.
+
+| Option                   | Description                                                                                                                                                                                                                                                                                                                      | Required |
+|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `--plugin=<path>`        | Path to, or identifier of the plugin to use.                                                                                                                                                                                                                                                                                     | Yes      |
+| `--input=<path>`         | Path to an input file.<br>To supply multiple input files, provide the `--input` argument multiple times.                                                                                                                                                                                                                         | Yes      |
+| `--output=<path>`        | Path to write the processed audio to.                                                                                                                                                                                                                                                                                            | Yes      |
+| `--override`             | Overridde the output file if it exists.<br>If this option is not set, processing is aborted if the output file exists.                                                                                                                                                                                                           | No       |
+| `--blockSize=<number>`   | The amount of samples to send to the audio plugin at once for processing. Defaults to 1024.                                                                                                                                                                                                                                      | No       |
+| `--outChannels=<number>` | The amount of channels to use for the plugin's output bus. Defaults to the amount of channels of the first input file.                                                                                                                                                                                                           | No       | 
+| `--param=<name>:<value>` | Sets the plugin parameter with the given name or index to the given value.<br>Both `name` and `value` can be quoted using single or double quotes.<br>To set multiple parameters, supply the `--param` argument multiple times.<br>Use the [`listParameters`](#list-plugin-parameters) command to list all available parameters. | No       |
 
 Example usage for a plugin with a main and a sidechain input bus:
 ```shell
-plugalyzer --plugin=/path/to/my/plugin.vst3 \
-  --input=main_input.wav                    \
-  --input=sidechain_input.wav               \
-  --output=out.wav
+plugalyzer process                    \
+  --plugin=/path/to/my/plugin.vst3    \
+  --input=main_input.wav              \
+  --input=sidechain_input.wav         \
+  --output=out.wav                    \
+  --param="Wet/Dry Mix":0.2           \
+  --param=Distortion:Off
 ```
 
-## Bus layouts
+### Bus layouts
 The bus layout requested from the plugin is based on the input files.
 Each input file is provided to the plugin on a separate bus, each bus having the same amount of channels as the respective input file.
 
 Plugalyzer only supports a single output bus, defaulting to the same amount of channels as the main input bus.
-This can be overridden using the `--outChannels` option.
+The amount of output channels can be overridden using the `--outChannels` option.
 
-## Limitations
+### Processing limitations
 - Plugalyzer does not support showing plugin GUIs of any kind. Since processing is not done in real-time, this wouldn't be too useful, either way.
-- There's currently no way to adjust any plugin parameters - audio is processed with the plugin's default parameters.
 - Only a single output bus is supported.
+
+## List plugin parameters
+The `listParameters` command lists all available plugin parameters and their value range.
+
+| Option                  | Description                                                                                                                                                              | Required |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `--plugin=<path>`       | Path to, or identifier of the plugin to use.                                                                                                                             | Yes      |
+| `--blockSize=<number>`  | The processing block size to initialize the plugin with. This is only needed when a plugin doesn't support initialization with the default block size. Defaults to 1024. | No       |
+| `--sampleRate=<number>` | The sample rate to initialize the plugin with. This is only needed when a plugin doesn't support initialization with the default sample rate. Defaults to 44100          | No       |
+
+Example usage:
+```shell
+plugalyzer listParameters --plugin=/path/to/my/plugin.vst3
+```
+
+Example output:
+```shell
+Loaded plugin "Black Box Analog Design HG-2".
+
+Plugin parameters: 
+0: Power
+   Values:  Off, On
+   Default: On
+1: Saturation Frequency
+   Values:  Low, Flat, High
+   Default: Flat
+2: Saturation In
+   Values:  Off, On
+   Default: Off
+3: Saturation
+   Values:  0 % to 100 %
+   Default: 50 %
+
+[...]
+```
+
+### Limitations
+- Plugin parameters with a set of discrete values (i.e. not a floating-point range) that aren't correctly marked as such
+  will not list all valid values. This issue arises, for example, when a JUCE plugin uses the deprecated
+  `juce::AudioProcessorValueTreeState::Parameter` class where `juce::AudioParameterChoice` would be a better fit.
+
+# Installation
+There are currently no pre-built binaries available for download, primarily because I do not have machines with all major operating systems available.  
+To compile this project yourself, clone it and build it via CMake.  
+I recommend JetBrain's CLion for its excellent CMake support.

--- a/Source/Plugalyzer.cpp
+++ b/Source/Plugalyzer.cpp
@@ -1,9 +1,8 @@
 #include "Plugalyzer.h"
 
-void plugalyze(const juce::String& pluginPath, const std::vector<juce::File>& inputFiles,
-               const juce::File& outputFile, int blockSize,
-               std::optional<int> numOutputChannelsOpt) {
-
+std::unique_ptr<juce::AudioPluginInstance> createPluginInstance(const juce::String& pluginPath,
+                                                                double initialSampleRate,
+                                                                int initialBlockSize) {
     juce::AudioPluginFormatManager audioPluginFormatManager;
     audioPluginFormatManager.addDefaultFormats();
 
@@ -24,6 +23,27 @@ void plugalyze(const juce::String& pluginPath, const std::vector<juce::File>& in
         pluginDescription = *pluginDescriptions[0];
     }
 
+    // create plugin instance
+    std::unique_ptr<juce::AudioPluginInstance> plugin;
+    {
+        juce::String err;
+        plugin = audioPluginFormatManager.createPluginInstance(pluginDescription, initialSampleRate,
+                                                               initialBlockSize, err);
+
+        if (!plugin) {
+            juce::ConsoleApplication::fail("Error creating plugin instance: " + err);
+        }
+    }
+
+    return plugin;
+}
+
+void printPluginInfo(const juce::AudioPluginInstance& plugin) {
+    std::cout << "Loaded plugin \"" << plugin.getName() << "\"." << std::endl << std::endl;
+}
+
+void process(const juce::String& pluginPath, const std::vector<juce::File>& inputFiles,
+             const juce::File& outputFile, int blockSize, std::optional<int> numOutputChannelsOpt) {
     // parse the input files
     juce::AudioFormatManager audioFormatManager;
     audioFormatManager.registerBasicFormats();
@@ -52,18 +72,6 @@ void plugalyze(const juce::String& pluginPath, const std::vector<juce::File>& in
         maxInputLength = std::max(maxInputLength, inputFileReader->lengthInSamples);
     }
 
-    // create plugin instance
-    std::unique_ptr<juce::AudioPluginInstance> plugin;
-    {
-        juce::String err;
-        plugin = audioPluginFormatManager.createPluginInstance(pluginDescription, sampleRate,
-                                                               blockSize, err);
-
-        if (!plugin) {
-            juce::ConsoleApplication::fail("Error creating plugin instance: " + err);
-        }
-    }
-
     // create the plugin's bus layout with an input bus for each input file
     unsigned int totalNumInputChannels = 0;
     juce::AudioPluginInstance::BusesLayout layout;
@@ -78,6 +86,10 @@ void plugalyze(const juce::String& pluginPath, const std::vector<juce::File>& in
     unsigned int totalNumOutputChannels =
         numOutputChannelsOpt.value_or(inputFileReaders[0]->numChannels);
     layout.outputBuses.add(juce::AudioChannelSet::canonicalChannelSet(totalNumOutputChannels));
+
+    // create the plugin instance
+    auto plugin = createPluginInstance(pluginPath, sampleRate, blockSize);
+    printPluginInfo(*plugin);
 
     // apply the channel layout
     if (!plugin->setBusesLayout(layout)) {
@@ -129,5 +141,55 @@ void plugalyze(const juce::String& pluginPath, const std::vector<juce::File>& in
         outWriter->writeFromAudioSampleBuffer(sampleBuffer, 0, blockSize);
 
         sampleIndex += blockSize;
+    }
+}
+
+void listParameters(const juce::String& pluginPath, double initialSampleRate,
+                    int initialBlockSize) {
+    auto plugin = createPluginInstance(pluginPath, initialSampleRate, initialBlockSize);
+    printPluginInfo(*plugin);
+
+    std::cout << "Plugin parameters: " << std::endl;
+
+    auto params = plugin->getParameters();
+
+    // calculate the amount of characters the maximum parameter index has
+    // for alignment purposes
+    auto maxIdxStrLength = juce::String(params.size() - 1).length();
+
+    for (auto* param : params) {
+        // calculate the indent of the index to align all entries nicely
+        auto idxStrLength = juce::String(param->getParameterIndex()).length();
+        std::string idxIndent(maxIdxStrLength - idxStrLength, ' ');
+
+        // index: name
+        std::cout << idxIndent << param->getParameterIndex() << ": " << param->getName(100)
+                  << std::endl;
+
+        // calculate the indent of entries for alignment
+        std::string indent(2 + maxIdxStrLength, ' ');
+
+        // print the parameter's values
+        std::cout << indent << "Values:  ";
+        
+        if (auto valueStrings = param->getAllValueStrings(); !valueStrings.isEmpty()) {
+            // list all discrete values
+            for (int i = 0; i < valueStrings.size(); i++) {
+                std::cout << valueStrings[i];
+                if (i != valueStrings.size() - 1) {
+                    std::cout << ", ";
+                } else {
+                    std::cout << std::endl;
+                }
+            }
+        } else {
+            // print the range of values that is supported
+            std::cout << param->getText(0, 1024) << param->getLabel() << " to "
+                      << param->getText(1, 1024) << param->getLabel() << std::endl;
+        }
+
+        // print the default value
+        std::cout << indent << "Default: " << param->getText(param->getDefaultValue(), 1024)
+                  << param->getLabel() << std::endl;
     }
 }

--- a/Source/Plugalyzer.h
+++ b/Source/Plugalyzer.h
@@ -4,6 +4,7 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
 void process(const juce::String& pluginPath, const std::vector<juce::File>& inputFiles,
-             const juce::File& outputFile, int blockSize, std::optional<int> numOutputChannelsOpt);
+             const juce::File& outputFile, int blockSize, std::optional<int> numOutputChannelsOpt,
+             const std::vector<std::pair<juce::String, juce::String>>& params);
 
 void listParameters(const juce::String& pluginPath, double initialSampleRate, int initialBlockSize);

--- a/Source/Plugalyzer.h
+++ b/Source/Plugalyzer.h
@@ -3,6 +3,7 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 
-void plugalyze(const juce::String& pluginPath, const std::vector<juce::File>& inputFiles,
-               const juce::File& outputFile, int blockSize,
-               std::optional<int> numOutputChannelsOpt);
+void process(const juce::String& pluginPath, const std::vector<juce::File>& inputFiles,
+             const juce::File& outputFile, int blockSize, std::optional<int> numOutputChannelsOpt);
+
+void listParameters(const juce::String& pluginPath, double initialSampleRate, int initialBlockSize);

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -2,22 +2,21 @@
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 
-void runCommandLine(const juce::String& commandLineParameters) {
-    juce::ArgumentList args("", commandLineParameters);
+std::vector<juce::File> getInputFileArguments(const juce::ArgumentList& _args) {
+    // create a copy to keep the original argument list unmodified
+    // when consuming the input options
+    juce::ArgumentList args = _args;
 
-    // parse plugin option
-    args.failIfOptionIsMissing("--plugin");
-    auto pluginPath = args.getValueForOption("--plugin");
-
-    // parse input file option(s).
-    // each input file will be sent to the plugin in a separate bus.
     std::vector<juce::File> inputFiles;
     args.failIfOptionIsMissing("--input");
     while (args.containsOption("--input")) {
         inputFiles.push_back(args.getExistingFileForOptionAndRemove("--input"));
     }
 
-    // parse output file option
+    return inputFiles;
+}
+
+juce::File getOutputFileArgument(const juce::ArgumentList& args) {
     args.failIfOptionIsMissing("--output");
     auto outputFile = args.getFileForOption("--output");
     if (outputFile.existsAsFile() && !args.containsOption("--overwrite")) {
@@ -25,6 +24,15 @@ void runCommandLine(const juce::String& commandLineParameters) {
             "Output file already exists! Use --overwrite to overwrite the file.");
     }
 
+    return outputFile;
+}
+
+juce::String getPluginArgument(const juce::ArgumentList& args) {
+    args.failIfOptionIsMissing("--plugin");
+    return args.getValueForOption("--plugin");
+}
+
+int getBlockSizeArgument(const juce::ArgumentList& args) {
     // parse optional block size option
     int blockSize = 1024;
     if (args.containsOption("--blockSize")) {
@@ -34,7 +42,10 @@ void runCommandLine(const juce::String& commandLineParameters) {
         }
     }
 
-    // parse optional output channel count option
+    return blockSize;
+}
+
+std::optional<int> getOutputChannelCountArgument(const juce::ArgumentList& args) {
     std::optional<int> numOutputChannelsOpt;
     if (args.containsOption("--outChannels")) {
         numOutputChannelsOpt = args.getValueForOption("--outChannels").getIntValue();
@@ -43,7 +54,62 @@ void runCommandLine(const juce::String& commandLineParameters) {
         }
     }
 
-    plugalyze(pluginPath, inputFiles, outputFile, blockSize, numOutputChannelsOpt);
+    return numOutputChannelsOpt;
+}
+
+double getSampleRateArgument(const juce::ArgumentList& args) {
+    // parse optional sample rate option
+    double sampleRate = 44100;
+    if (args.containsOption("--sampleRate")) {
+        sampleRate = args.getValueForOption("--sampleRate").getDoubleValue();
+        if (sampleRate <= 0) {
+            juce::ConsoleApplication::fail("sampleRate must be a positive number");
+        }
+    }
+
+    return sampleRate;
+}
+
+void runProcessCommand(const juce::ArgumentList& args) {
+    // parse plugin option
+    auto pluginPath = getPluginArgument(args);
+
+    // parse input file option(s).
+    // each input file will be sent to the plugin in a separate bus.
+    auto inputFiles = getInputFileArguments(args);
+
+    auto outputFile = getOutputFileArgument(args);
+    auto blockSize = getBlockSizeArgument(args);
+
+    // parse optional output channel count option
+    auto numOutputChannelsOpt = getOutputChannelCountArgument(args);
+
+    process(pluginPath, inputFiles, outputFile, blockSize, numOutputChannelsOpt);
+}
+
+void runListParametersCommand(const juce::ArgumentList& args) {
+    auto pluginPath = getPluginArgument(args);
+    auto sampleRate = getSampleRateArgument(args);
+    auto blockSize = getBlockSizeArgument(args);
+
+    listParameters(pluginPath, sampleRate, blockSize);
+}
+
+void runCommandLine(const juce::String& commandLineParameters) {
+    juce::ArgumentList args("", commandLineParameters);
+
+    if (args.arguments.isEmpty()) {
+        juce::ConsoleApplication::fail(
+            "Must have at least one argument to indicate the desired action");
+    }
+    auto command = args.arguments.removeAndReturn(0).text;
+    if (command == "process") {
+        runProcessCommand(args);
+    } else if (command == "listParameters") {
+        runListParametersCommand(args);
+    } else {
+        juce::ConsoleApplication::fail("Invalid command: " + command);
+    }
 }
 
 class PlugalyzerApplication : public juce::JUCEApplicationBase {


### PR DESCRIPTION
Moves the current behaviour behind the `process` command, and adds the `listParameters` command to list a plugin's parameters.